### PR TITLE
chore: use RELEASE_PAT for publish release checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary
- Use `RELEASE_PAT` org secret instead of `GITHUB_TOKEN` for release checkout
- Allows publish workflow to push version bump commits + tags to protected main branch

## Test plan
- [ ] Trigger `workflow_dispatch` patch release after merge