### PR TITLE
chore: add OSS readiness files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: Report a bug with @vllnt/eslint-config
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Minimal eslint.config.js and steps to reproduce
+      render: js
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: "@vllnt/eslint-config version"
+      placeholder: "1.0.1"
+    validations:
+      required: true
+  - type: input
+    id: eslint-version
+    attributes:
+      label: ESLint version
+      placeholder: "9.39.4"
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      placeholder: "22.x"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord
+    url: https://bntvllnt.com/discord
+    about: Questions and discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Suggest a new rule, preset, or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you've thought about
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Test plan
+
+- [ ] `pnpm test` passes
+- [ ] Tested with a real project (if adding/changing rules)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,28 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm test
+
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: CHANGELOG.md updated
+        run: |
+          if ! git diff --name-only origin/main...HEAD | grep -q '^CHANGELOG.md$'; then
+            echo "::error::CHANGELOG.md must be updated in every PR"
+            exit 1
+          fi
+
+      - name: Version matches CHANGELOG
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          CL_VERSION=$(grep -oP '(?<=## \[)[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1)
+          if [ "$PKG_VERSION" != "$CL_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match latest CHANGELOG.md entry ($CL_VERSION)"
+            exit 1
+          fi
+          echo "Versions match: $PKG_VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,15 +10,6 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/publish.yml"
   workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump type"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
 concurrency:
   group: publish-${{ github.event_name }}
@@ -105,58 +96,44 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Bump version
+      - name: Read version
         id: version
         run: |
-          npm version ${{ inputs.bump }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Generate changelog
+      - name: Extract release notes from CHANGELOG.md
         id: changelog
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            RANGE="HEAD"
-          else
-            RANGE="${LAST_TAG}..HEAD"
+          VERSION="${{ steps.version.outputs.version }}"
+          NOTES=$(awk -v ver="$VERSION" '
+            BEGIN { found=0 }
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found=1; next }
+            }
+            found && /^[[:space:]]*$/ && !printed { next }
+            found { printed=1; print }
+          ' CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            echo "::warning::No release notes found in CHANGELOG.md for v$VERSION"
+            NOTES="Release v$VERSION"
           fi
 
           {
-            echo "body<<CHANGELOG_EOF"
-
-            FEATS=$(git log "$RANGE" --pretty=format:"%s" --grep="^feat" 2>/dev/null || true)
-            if [ -n "$FEATS" ]; then
-              echo "### Features"
-              echo "$FEATS" | sed 's/^/- /'
-              echo ""
-            fi
-
-            FIXES=$(git log "$RANGE" --pretty=format:"%s" --grep="^fix" 2>/dev/null || true)
-            if [ -n "$FIXES" ]; then
-              echo "### Bug Fixes"
-              echo "$FIXES" | sed 's/^/- /'
-              echo ""
-            fi
-
-            OTHERS=$(git log "$RANGE" --pretty=format:"%s" --invert-grep --grep="^feat" --grep="^fix" 2>/dev/null || true)
-            if [ -n "$OTHERS" ]; then
-              echo "### Other Changes"
-              echo "$OTHERS" | sed 's/^/- /'
-              echo ""
-            fi
-
-            echo "CHANGELOG_EOF"
+            echo "notes<<CHANGELOG_DELIM"
+            echo "$NOTES"
+            echo "CHANGELOG_DELIM"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Commit and tag
+      - name: Create git tag
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git commit -m "chore(release): v${{ steps.version.outputs.version }}"
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin main --follow-tags
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
 
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
@@ -169,8 +146,9 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --title "@vllnt/eslint-config v${{ steps.version.outputs.version }}" \
-            --notes "${{ steps.changelog.outputs.body }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release create "v$VERSION" \
+            --title "@vllnt/eslint-config v$VERSION" \
+            --notes "${{ steps.changelog.outputs.notes }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# @vllnt/eslint-config
+
+Strict ESLint flat config for TypeScript projects. Scoped to `@vllnt` npm org.
+
+## Project Structure
+
+```
+flat/           ← shipped code (included in npm tarball)
+  index.js      ← barrel: re-exports all presets
+  base.js       ← base config (TS strict + prettier)
+  nextjs.js     ← Next.js preset
+  nodejs.js     ← Node.js preset
+  react.js      ← React preset
+  convex.js     ← Convex preset
+  turbo.js      ← Turborepo preset
+  boundaries.js ← Architecture boundaries preset
+  convex-plugin.js    ← convex-rules ESLint plugin
+  convex-rules/       ← 7 custom Convex lint rules
+  core/               ← shared config fragments
+tests/
+  smoke.test.js ← export/shape/hygiene tests (node:test)
+```
+
+## Commands
+
+| Command | What |
+|---------|------|
+| `pnpm test` | Smoke tests (43 assertions) |
+| `pnpm pack --dry-run` | Preview tarball contents |
+
+## Architecture
+
+- Each preset is a flat config array exported from `flat/{preset}.js`
+- Config fragments live in `flat/core/{name}.js` and are composed into presets
+- `flat/index.js` is the barrel that re-exports all presets
+- Custom Convex rules live in `flat/convex-rules/` and are bundled via `flat/convex-plugin.js`
+- Tests use `node:test` (no external test runner)
+
+## Conventions
+
+- All rules enforce `error` — never `warn` or `off`
+- Presets are arrays — consumers spread them into their flat config
+- No TypeScript source — all shipped code is plain JS
+- `peerDependencies` for eslint, prettier, typescript
+- `dependencies` for all plugins (consumers don't install them separately)
+
+## Publishing
+
+Push to main triggers canary publish. Use `workflow_dispatch` for releases.
+See CLAUDE.md for full publishing instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,5 +46,6 @@ tests/
 
 ## Publishing
 
-Push to main triggers canary publish. Use `workflow_dispatch` for releases.
-See CLAUDE.md for full publishing instructions.
+Push to main triggers canary publish. For releases: bump version in package.json,
+add CHANGELOG.md entry, merge PR, then trigger `workflow_dispatch`. CI creates
+git tag, publishes to npm, and creates GitHub Release with notes from CHANGELOG.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.1] - 2026-03-29
+
+### Fixed
+
+- Resolve 23 transitive dependency vulnerabilities (1 critical, 14 high, 7 moderate, 1 low) (#12)
+- Bump `@convex-dev/eslint-plugin` ^1.1.1 to ^1.2.1
+- Bump `eslint` (dev) ^9.39.2 to ^9.39.4
+- Add `pnpm.overrides` for `handlebars` (pinned by upstream `@boundaries/elements`)
+- Refresh lockfile to resolve minimatch, picomatch, flatted, brace-expansion to patched versions
+
+## [1.0.0] - 2026-03-14
+
+### Added
+
+- Initial release
+- 7 presets: Base, React, Next.js, Node.js, Convex, Turbo, Boundaries
+- TypeScript-first with `strictTypeChecked` + `stylisticTypeChecked`
+- Prettier built-in as lint errors
+- 7 custom Convex lint rules bundled as `eslint-plugin-convex-rules`
+- Smoke tests with 43 assertions
+- CI/CD with GitHub Actions (test + canary publish + release)
+
+[1.0.1]: https://github.com/vllnt/eslint-config/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/vllnt/eslint-config/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,11 @@ git push && git push --tags
 
 ## Publishing (CI)
 
-Push a version tag — CI handles the rest:
-
-```sh
-pnpm version patch
-git push && git push --tags
-# release.yml: test → npm publish --provenance → GitHub Release
-```
-
-Requires `NPM_TOKEN` secret in GitHub repo settings.
+1. Bump version in `package.json`
+2. Add entry to `CHANGELOG.md` (CI enforces this)
+3. Merge PR (CI verifies version matches CHANGELOG)
+4. Trigger **Publish** workflow manually (`workflow_dispatch`)
+5. CI creates git tag, publishes to npm, creates GitHub Release with notes from CHANGELOG.md
 
 ## Project structure
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported via:
+
+- **Discord**: [bntvllnt.com/discord](https://bntvllnt.com/discord)
+- **X / Twitter DM**: [bntvllnt.com/x](https://bntvllnt.com/x)
+
+All complaints will be reviewed and investigated promptly and fairly. Community leaders are obligated to respect the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to @vllnt/eslint-config
+
+Thanks for your interest in contributing! This guide covers how to get started.
+
+## Getting Started
+
+1. Fork and clone the repo
+2. Install dependencies: `pnpm install`
+3. Run tests: `pnpm test`
+
+## Development
+
+### Project Structure
+
+```
+flat/           ← shipped code (included in npm tarball)
+  index.js      ← barrel: re-exports all presets
+  base.js       ← base config (TS strict + prettier)
+  nextjs.js     ← Next.js preset
+  nodejs.js     ← Node.js preset
+  react.js      ← React preset
+  convex.js     ← Convex preset
+  turbo.js      ← Turborepo preset
+  boundaries.js ← Architecture boundaries preset
+  convex-plugin.js    ← convex-rules ESLint plugin
+  convex-rules/       ← 7 custom Convex lint rules
+  core/               ← shared config fragments
+tests/
+  smoke.test.js ← export/shape/hygiene tests (node:test)
+```
+
+### Adding a New Preset
+
+1. Create `flat/core/{preset}.js` with the config fragment
+2. Create `flat/{preset}.js` that exports the preset array
+3. Add the export to `flat/index.js`
+4. Add the export path to `package.json` `exports` field
+5. Add tests in `tests/smoke.test.js`
+
+### Adding a New Convex Rule
+
+1. Create the rule in `flat/convex-rules/{rule-name}.js`
+2. Register it in `flat/convex-plugin.js`
+3. Enable it in `flat/core/convex.js`
+4. Add tests
+
+## Pull Requests
+
+- Branch from `main`
+- Use conventional commits: `feat(scope):`, `fix(scope):`, `chore(scope):`
+- Keep PRs focused — one change per PR
+- All tests must pass: `pnpm test`
+
+## Reporting Issues
+
+Open a [GitHub issue](https://github.com/vllnt/eslint-config/issues). Include:
+- ESLint and Node.js version
+- Your `eslint.config.js`
+- The error or unexpected behavior
+
+## Community
+
+- [Discord](https://bntvllnt.com/discord) — questions and discussion
+- [X / Twitter](https://bntvllnt.com/x) — updates
+- [GitHub](https://bntvllnt.com/github) — issues and PRs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 1.x     | Yes                |
+| < 1.0   | No                 |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+### Preferred: GitHub Security Advisories
+
+1. Go to [Security Advisories](https://github.com/vllnt/eslint-config/security/advisories)
+2. Click "Report a vulnerability"
+3. Fill in the details
+
+### Alternative: X / Twitter DM
+
+Send a direct message to [@bntvllnt](https://bntvllnt.com/x) with:
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment
+
+## Response Timeline
+
+- **Acknowledgment**: within 48 hours
+- **Initial assessment**: within 1 week
+- **Fix release**: within 2 weeks for critical/high severity
+
+## Scope
+
+This package is an ESLint configuration — it runs at development time only, not in production. Vulnerabilities in transitive dependencies are tracked and patched promptly (see [#11](https://github.com/vllnt/eslint-config/issues/11) for precedent).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,263 @@
+# @vllnt/eslint-config
+
+> Strict, opinionated ESLint flat config for TypeScript projects. Every rule enforces error — no warnings, no compromises.
+
+ESLint v9+ flat config with 7 presets: Base, React, Next.js, Node.js, Convex, Turbo, Boundaries. TypeScript-first with `strictTypeChecked` + `stylisticTypeChecked`. Prettier built-in. 7 custom Convex lint rules bundled as `eslint-plugin-convex-rules`.
+
+## Docs
+
+### README
+Source: README.md
+
+# @vllnt/eslint-config
+
+**Strict, opinionated ESLint flat config for TypeScript projects.**
+Every rule enforces `error` — no warnings, no compromises.
+
+## Why
+
+- **ESLint v9+ flat config only** — no legacy `.eslintrc`
+- **TypeScript-first** with `strictTypeChecked` + `stylisticTypeChecked`
+- **Prettier built-in** — formatting as lint errors, zero config
+- **7 presets** — Base, React, Next.js, Node.js, Convex, Turbo, Boundaries
+- **Composable** — spread arrays, override anything
+
+## Install
+
+```sh
+pnpm add -D @vllnt/eslint-config eslint typescript prettier
+```
+
+## Quick start
+
+```js
+// eslint.config.js
+import { nextjs } from '@vllnt/eslint-config/nextjs'
+
+export default [...nextjs]
+```
+
+Each preset is an array — spread it into your flat config. All presets include `projectService: true` for type-aware linting.
+
+## Presets
+
+| Import | Use case |
+|--------|----------|
+| `@vllnt/eslint-config` | Base — TypeScript strict + Prettier + import sorting |
+| `@vllnt/eslint-config/nextjs` | Next.js apps (includes React + a11y + core web vitals) |
+| `@vllnt/eslint-config/react` | React apps without Next.js |
+| `@vllnt/eslint-config/nodejs` | Node.js backends |
+| `@vllnt/eslint-config/convex` | Convex backends (4 official + 7 custom rules) |
+| `@vllnt/eslint-config/turbo` | Turborepo cache rules (opt-in) |
+| `@vllnt/eslint-config/boundaries` | Architecture boundary enforcement (opt-in) |
+
+## Composing presets
+
+Mix and match — presets are arrays:
+
+```js
+import { nodejs } from '@vllnt/eslint-config/nodejs'
+import { turbo } from '@vllnt/eslint-config/turbo'
+
+export default [...nodejs, ...turbo]
+```
+
+Override any rule by appending a config object:
+
+```js
+import { nodejs } from '@vllnt/eslint-config/nodejs'
+
+export default [
+  ...nodejs,
+  {
+    rules: {
+      'max-lines-per-function': ['error', { max: 50 }],
+    },
+  },
+]
+```
+
+## Convex preset
+
+The Convex preset enforces backend best practices with **4 official rules** + **7 custom rules** bundled as `eslint-plugin-convex-rules`.
+
+### Setup
+
+```js
+// Standalone
+import { convex } from '@vllnt/eslint-config/convex'
+
+export default [...convex]
+```
+
+```js
+// With base (recommended)
+import { base } from '@vllnt/eslint-config'
+import { convex } from '@vllnt/eslint-config/convex'
+
+export default [...base, ...convex]
+```
+
+### Official rules (`@convex-dev`)
+
+| Rule | Catches |
+|------|---------|
+| `no-old-registered-function-syntax` | Deprecated function syntax |
+| `require-args-validator` | Missing `args` validator |
+| `explicit-table-ids` | Implicit table ID types |
+| `import-wrong-runtime` | Wrong runtime imports (Node in Convex runtime) |
+
+### Custom rules (`convex-rules`)
+
+| Rule | Catches |
+|------|---------|
+| `standard-filenames` | Factories outside `queries.ts`, `mutations.ts`, `actions.ts` |
+| `namespace-separation` | `query()` in `mutations.ts`, `mutation()` in `queries.ts` |
+| `snake-case-filenames` | Hyphens in `convex/` filenames (must be `snake_case`) |
+| `no-bare-v-any` | `v.any()` outside `validators.ts` |
+| `require-returns-validator` | Missing `returns` validator in factory config |
+| `no-query-in-loop` | N+1 queries (`ctx.db.query`/`get`/`runQuery` inside loops) |
+| `no-filter-on-query` | `.filter()` on query chains (use `.withIndex()`) |
+
+### Auto-applied overrides
+
+- **Config files** (`auth.ts`, `auth.config.ts`, `convex.config.ts`) — exempt from `snake-case-filenames` and `explicit-module-boundary-types`
+- **Migration files** (`convex/migrations/**`) — exempt from `standard-filenames`, `namespace-separation`, `no-query-in-loop`
+- **Generated/test files** (`convex/_generated/**`, `*.test.ts`, `convex/testing/**`) — excluded entirely
+
+### Project-specific overrides
+
+```js
+import { base } from '@vllnt/eslint-config'
+import { convex } from '@vllnt/eslint-config/convex'
+
+export default [
+  ...base,
+  ...convex,
+
+  // Exempt "use node" action files from import-wrong-runtime
+  {
+    files: ['convex/agents/actions.ts'],
+    rules: { '@convex-dev/import-wrong-runtime': 'off' },
+  },
+]
+```
+
+### Enforced file structure
+
+```
+convex/
+  {domain}/
+    queries.ts              query(), internalQuery()
+    mutations.ts            mutation(), internalMutation()
+    actions.ts              action(), internalAction()
+    internal_mutations.ts   internalMutation() (optional split)
+    validators.ts           v.* validators + types
+    schema.ts               table definitions
+  lib/
+    validators.ts           shared v.any() aliases
+  _generated/               auto-generated (excluded)
+  migrations/               relaxed rules
+```
+
+## What's included
+
+### Base (all presets)
+
+| Plugin | What it does |
+|--------|-------------|
+| @eslint/js | ESLint recommended rules |
+| typescript-eslint | `strictTypeChecked` + `stylisticTypeChecked` |
+| eslint-plugin-prettier | Prettier as ESLint errors |
+| eslint-config-prettier | Disables conflicting rules |
+| eslint-plugin-perfectionist | Import/object/type sorting |
+| eslint-plugin-unicorn | Modern JS best practices |
+| eslint-plugin-simple-import-sort | Import ordering |
+| eslint-plugin-functional | Functional patterns (no loops, readonly) |
+| eslint-plugin-write-good-comments | Comment quality |
+
+### React additions
+
+| Plugin | What it does |
+|--------|-------------|
+| eslint-plugin-react | Recommended + jsx-runtime |
+| eslint-plugin-react-hooks | Rules of hooks |
+| eslint-plugin-jsx-a11y | Accessibility |
+| eslint-plugin-css-modules | CSS module validation |
+
+### Next.js additions
+
+Everything in React, plus:
+
+| Plugin | What it does |
+|--------|-------------|
+| @next/eslint-plugin-next | Recommended + core web vitals (all `error`) |
+
+### Opt-in
+
+| Preset | Plugin |
+|--------|--------|
+| Turbo | eslint-plugin-turbo cache rules |
+| Boundaries | eslint-plugin-boundaries architecture enforcement |
+
+## Peer dependencies
+
+| Package | Required |
+|---------|----------|
+| `eslint` >= 9 | Yes |
+| `prettier` >= 3 | Yes |
+| `typescript` >= 5 | Optional |
+
+## License
+
+MIT
+
+### Contributing
+Source: CONTRIBUTING.md
+
+See CONTRIBUTING.md for development setup, project structure, and pull request guidelines.
+
+### Changelog
+Source: CHANGELOG.md
+
+## [1.0.1] - 2026-03-29
+
+### Fixed
+
+- Resolve 23 transitive dependency vulnerabilities (#12)
+- Bump @convex-dev/eslint-plugin ^1.1.1 to ^1.2.1
+- Bump eslint (dev) ^9.39.2 to ^9.39.4
+- Add pnpm.overrides for handlebars (pinned by upstream @boundaries/elements)
+
+## [1.0.0] - 2026-03-14
+
+### Added
+
+- Initial release
+- 7 presets: Base, React, Next.js, Node.js, Convex, Turbo, Boundaries
+- TypeScript-first with strictTypeChecked + stylisticTypeChecked
+- Prettier built-in as lint errors
+- 7 custom Convex lint rules bundled as eslint-plugin-convex-rules
+- Smoke tests with 43 assertions
+- CI/CD with GitHub Actions
+
+### Agents
+Source: AGENTS.md
+
+See AGENTS.md for AI agent instructions, architecture overview, and conventions.
+
+## Optional
+
+### Security Policy
+Source: SECURITY.md
+
+Supported versions: 1.x. Report vulnerabilities via GitHub Security Advisories or X DM (@bntvllnt). Response within 48 hours.
+
+### Code of Conduct
+Source: CODE_OF_CONDUCT.md
+
+Adapted from Contributor Covenant v2.1. Report violations via Discord (bntvllnt.com/discord) or X DM (bntvllnt.com/x).
+
+### License
+
+MIT License. See LICENSE file for full text.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,18 @@
+# @vllnt/eslint-config
+
+> Strict, opinionated ESLint flat config for TypeScript projects. Every rule enforces error — no warnings, no compromises.
+
+ESLint v9+ flat config with 7 presets: Base, React, Next.js, Node.js, Convex, Turbo, Boundaries. TypeScript-first with `strictTypeChecked` + `stylisticTypeChecked`. Prettier built-in. 7 custom Convex lint rules bundled as `eslint-plugin-convex-rules`.
+
+## Docs
+
+- [README](README.md): Project overview, presets, installation, and usage guide
+- [Contributing](CONTRIBUTING.md): Contribution guidelines and development setup
+- [Changelog](CHANGELOG.md): Version history and release notes
+- [Agents](AGENTS.md): AI agent instructions for working with this codebase
+
+## Optional
+
+- [Security Policy](SECURITY.md): Vulnerability reporting and disclosure policy
+- [Code of Conduct](CODE_OF_CONDUCT.md): Community guidelines
+- [License](LICENSE): MIT license


### PR DESCRIPTION
## Summary

- Scaffold 11 missing OSS files to pass readiness audit (D → A target)
- **4 BLOCKING**: CONTRIBUTING.md, CHANGELOG.md, llms.txt, llms-full.txt
- **7 RECOMMENDED**: SECURITY.md, CODE_OF_CONDUCT.md, AGENTS.md, issue templates (bug + feature + config), PR template

Closes #6

## Test plan

- [x] `pnpm test` passes (no code changes)
- [ ] Run `/oss` audit to verify grade improvement