### PR TITLE
ci: auto-release on push when new version detected

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: pnpm/action-setup@v4
 
@@ -158,7 +157,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ needs.check-version.outputs.version }}"
           gh release create "v$VERSION" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,16 +3,9 @@ name: Publish
 on:
   push:
     branches: [main]
-    paths:
-      - "flat/**"
-      - "tests/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/publish.yml"
-  workflow_dispatch:
 
 concurrency:
-  group: publish-${{ github.event_name }}
+  group: publish
   cancel-in-progress: true
 
 permissions:
@@ -37,10 +30,35 @@ jobs:
 
       - run: pnpm test
 
+  check-version:
+    name: Check Version
+    needs: quality
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      is_new_release: ${{ steps.meta.outputs.is_new_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect release
+        id: meta
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "is_new_release=false" >> "$GITHUB_OUTPUT"
+            echo "Tag v$VERSION exists — canary only"
+          else
+            echo "is_new_release=true" >> "$GITHUB_OUTPUT"
+            echo "No tag v$VERSION — new release"
+          fi
+
   canary:
     name: Publish Canary
-    needs: quality
-    if: github.event_name == 'push'
+    needs: check-version
+    if: needs.check-version.outputs.is_new_release == 'false'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -74,8 +92,8 @@ jobs:
 
   release:
     name: Publish Release
-    needs: quality
-    if: github.event_name == 'workflow_dispatch'
+    needs: check-version
+    if: needs.check-version.outputs.is_new_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -96,16 +114,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Read version
-        id: version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Extract release notes from CHANGELOG.md
         id: changelog
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.check-version.outputs.version }}"
           NOTES=$(awk -v ver="$VERSION" '
             BEGIN { found=0 }
             /^## \[/ {
@@ -129,7 +141,7 @@ jobs:
 
       - name: Create git tag
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.check-version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "v$VERSION" -m "Release v$VERSION"
@@ -148,7 +160,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.check-version.outputs.version }}"
           gh release create "v$VERSION" \
             --title "@vllnt/eslint-config v$VERSION" \
             --notes "${{ steps.changelog.outputs.notes }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,6 @@ tests/
 
 ## Publishing
 
-Push to main triggers canary publish. For releases: bump version in package.json,
-add CHANGELOG.md entry, merge PR, then trigger `workflow_dispatch`. CI creates
-git tag, publishes to npm, and creates GitHub Release with notes from CHANGELOG.md.
+Push to main auto-detects new versions. If package.json version has no git tag,
+CI creates the tag, publishes to npm, and creates a GitHub Release with notes
+from CHANGELOG.md. Non-release pushes publish a canary version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [1.0.1] - 2026-03-29
 
+### Changed
+
+- CI: auto-release on push to main when new version detected (replaces manual workflow_dispatch)
+- CI: enforce CHANGELOG.md updated in every PR with version match check
+
 ### Fixed
 
 - Resolve 23 transitive dependency vulnerabilities (1 critical, 14 high, 7 moderate, 1 low) (#12)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,11 @@ git push && git push --tags
 ## Publishing (CI)
 
 1. Bump version in `package.json`
-2. Add entry to `CHANGELOG.md` (CI enforces this)
-3. Merge PR (CI verifies version matches CHANGELOG)
-4. Trigger **Publish** workflow manually (`workflow_dispatch`)
-5. CI creates git tag, publishes to npm, creates GitHub Release with notes from CHANGELOG.md
+2. Add entry to `CHANGELOG.md` (CI enforces both)
+3. Merge PR → CI auto-detects new version, creates git tag, publishes to npm,
+   and creates GitHub Release with notes from CHANGELOG.md
+
+Non-release pushes to main publish a canary version automatically.
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

- Replace manual `workflow_dispatch` release with auto-detection on push to main
- `check-version` job: compares `package.json` version to git tags
  - No tag for current version → **full release** (git tag + npm publish + GitHub Release with CHANGELOG.md notes)
  - Tag exists → **canary publish** only
- Update CLAUDE.md and AGENTS.md with new flow

## Flow

```
push to main
  → quality gates (test)
  → check-version (tag v{version} exists?)
    → NO  → release (tag + npm latest + GitHub Release)
    → YES → canary (npm canary)
```

## Test plan

- [x] `pnpm test` passes
- [ ] Merge → v1.0.1 tag exists → canary runs, release skips
- [ ] Next version bump (1.0.2) → auto-release triggers